### PR TITLE
Fix setup docs and configure backend build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Set environment variables via `.env` to connect to Groq, ElevenLabs, and an exte
 
 ```bash
 cd frontend
-pnpm install
-pnpm dev
+npm install
+npm run dev
 ```
 
 Configure `VITE_API_URL` in a `.env` file to point at the backend service.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,3 +17,10 @@ develop = [
     "alembic",
     "black",
 ]
+
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]


### PR DESCRIPTION
## Summary
- configure the backend package with a setuptools build backend so editable installs work
- update the frontend setup instructions to use npm instead of pnpm

## Testing
- pip install -e . *(fails in this environment: cannot download setuptools due to proxy restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68dff08aa374832e97549bf8fa44b8e4