### PR TITLE
Add missing pydantic-settings dependency to backend project

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "uvicorn[standard]",
     "sqlalchemy[asyncio]",
     "pydantic",
+    "pydantic-settings",
     "httpx",
     "python-dotenv",
 ]


### PR DESCRIPTION
## Summary
- add the missing pydantic-settings dependency so the FastAPI config module can load on Python 3.12

## Testing
- pip install -e . (fails: proxy error fetching setuptools)


------
https://chatgpt.com/codex/tasks/task_e_68e0305501ac832ea70914cb07800323