### PR TITLE
Connect chat UI to backend APIs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,10 +11,17 @@ export type PanelMode = 'chat' | 'call';
 function App() {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [mode, setMode] = useState<PanelMode>('chat');
+  const [activeChatId, setActiveChatId] = useState<string | null>(null);
 
   return (
     <div className="flex min-h-screen w-full flex-col overflow-hidden bg-primary-950 md:flex-row">
-      <ChatSidebar onOpenDrawer={() => setDrawerOpen(true)} onSwitchMode={setMode} activeMode={mode} />
+      <ChatSidebar
+        onOpenDrawer={() => setDrawerOpen(true)}
+        onSwitchMode={setMode}
+        activeMode={mode}
+        selectedChatId={activeChatId}
+        onSelectChat={setActiveChatId}
+      />
       <main className="relative flex flex-1 flex-col">
         <div className="pointer-events-none absolute inset-0 overflow-hidden">
           <div className="absolute -top-32 left-10 h-72 w-72 rounded-full bg-primary-500/20 blur-3xl md:left-32 md:h-96 md:w-96" />
@@ -38,7 +45,9 @@ function App() {
           </div>
         </header>
         <section className="relative z-10 flex flex-1">
-          <AnimatePresence mode="wait">{mode === 'chat' ? <ChatWindow key="chat" /> : <CallPanel key="call" />}</AnimatePresence>
+          <AnimatePresence mode="wait">
+            {mode === 'chat' ? <ChatWindow key="chat" chatId={activeChatId ?? undefined} /> : <CallPanel key="call" />}
+          </AnimatePresence>
         </section>
       </main>
       <KnowledgeDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -8,10 +8,8 @@ import 'prismjs/components/prism-python';
 import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-json';
 
-type Role = 'user' | 'assistant' | 'system';
-
 interface Props {
-  role: Role;
+  role: string;
   content: string;
 }
 

--- a/frontend/src/hooks/useChatApi.ts
+++ b/frontend/src/hooks/useChatApi.ts
@@ -2,8 +2,23 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
+export interface Message {
+  id: string;
+  role: string;
+  content: string;
+  created_at: string;
+  audio_url?: string | null;
+}
+
+export interface Chat {
+  id: string;
+  title: string;
+  created_at: string;
+  messages: Message[];
+}
+
 export function useChats() {
-  return useQuery({
+  return useQuery<Chat[]>({
     queryKey: ['chats'],
     queryFn: async () => {
       const response = await fetch(`${API_BASE}/chats/`);
@@ -15,8 +30,8 @@ export function useChats() {
 
 export function useCreateChat() {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: async (payload: { title: string }) => {
+  return useMutation<Chat, Error, { title: string }>({
+    mutationFn: async (payload) => {
       const response = await fetch(`${API_BASE}/chats/`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -26,6 +41,48 @@ export function useCreateChat() {
       return response.json();
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['chats'] }),
+  });
+}
+
+export function useChatMessages(chatId: string | undefined) {
+  return useQuery<Message[]>({
+    queryKey: ['chats', chatId, 'messages'],
+    enabled: Boolean(chatId),
+    queryFn: async () => {
+      if (!chatId) throw new Error('Chat ID is required');
+      const response = await fetch(`${API_BASE}/chats/${chatId}/messages`);
+      if (!response.ok) throw new Error('Unable to load messages');
+      return response.json();
+    },
+  });
+}
+
+type MessagePayload = {
+  role: string;
+  content: string;
+  audio_url?: string | null;
+};
+
+export function useSendMessage(chatId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation<Message, Error, MessagePayload>({
+    mutationFn: async (payload) => {
+      if (!chatId) throw new Error('Chat ID is required');
+      const response = await fetch(`${API_BASE}/chats/${chatId}/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) throw new Error('Unable to send message');
+      return response.json();
+    },
+    onSuccess: (message) => {
+      if (!chatId) return;
+      queryClient.setQueryData<Message[]>(['chats', chatId, 'messages'], (existing) =>
+        existing ? [...existing, message] : [message]
+      );
+      queryClient.invalidateQueries({ queryKey: ['chats'] });
+    },
   });
 }
 


### PR DESCRIPTION
## Summary
- add a REST endpoint that returns messages for a given chat
- wire the chat sidebar and window components to real backend data and mutations
- extend React Query hooks to fetch and send chat messages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e13fba5abc832e9a35e155038419ce