### PR TITLE
Improve CORS support and initialize database schema

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,8 +28,20 @@ class Settings(BaseSettings):
     elevenlabs_api_key: str = Field("", description="API key for ElevenLabs text-to-speech streaming.")
 
     allowed_origins: List[str] = Field(
-        default_factory=lambda: ["http://localhost:5173", "http://localhost:3000"],
+        default_factory=lambda: [
+            "http://localhost:5173",
+            "http://localhost:3000",
+            "http://127.0.0.1:5173",
+            "http://127.0.0.1:3000",
+        ],
         description="Origins permitted to access the API via CORS.",
+    )
+    allowed_origin_regex: str | None = Field(
+        default=r"http://(localhost|127\.0\.0\.1)(:\\d+)?",
+        description=(
+            "Optional regular expression that will be used to match additional allowed"
+            " origins for CORS requests."
+        ),
     )
 
     signalling_secret: str = Field(

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -38,8 +38,13 @@ def get_session_factory() -> async_sessionmaker[AsyncSession]:
 async def lifespan(app) -> AsyncIterator[None]:
     """Manage engine lifecycle for FastAPI."""
 
+    from app import models  # noqa: F401  # Ensure models are registered with SQLAlchemy metadata.
+
     _create_engine()
     try:
+        if _engine is not None:
+            async with _engine.begin() as connection:
+                await connection.run_sync(Base.metadata.create_all)
         yield
     finally:
         if _engine is not None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ app = FastAPI(title=settings.app_name, debug=settings.debug, lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.allowed_origins,
+    allow_origin_regex=settings.allowed_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- broaden the backend CORS configuration to cover common localhost and 127.0.0.1 origins
- expose an origin regex option and wire it into the FastAPI middleware
- create database tables automatically during startup so chat persistence works out of the box

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e2b2ca203c832ebca9e99ca61196be