### PR TITLE
Fix Pydantic ORM configuration for chat schemas

### DIFF
--- a/backend/app/schemas/chat.py
+++ b/backend/app/schemas/chat.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class MessageBase(BaseModel):
@@ -26,8 +26,7 @@ class Message(MessageBase):
     id: str
     created_at: datetime
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ChatBase(BaseModel):
@@ -47,5 +46,4 @@ class Chat(ChatBase):
     created_at: datetime
     messages: list[Message] = Field(default_factory=list)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- switch chat response schemas to use Pydantic v2 ConfigDict with from_attributes enabled

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2b65f02b0832ebb3368fd19de1818