### PR TITLE
Add Postgres docker compose setup and fix async chat retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ uvicorn app.main:app --reload
 
 Set environment variables via `.env` to connect to Groq, ElevenLabs, and an external database/vector store. A starter template is provided in [`backend/.env.sample`](backend/.env.sample).
 
+To run the Postgres database used by the backend, start the bundled Docker Compose stack:
+
+```bash
+docker compose up -d postgres
+```
+
+This provisions a Postgres 16 instance with credentials matching the defaults in the backend `.env.sample`. Update `DATABASE_URL` if you choose different credentials or a remote host.
+
 ### Frontend
 
 ```bash

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,21 +1,19 @@
-# Backend environment configuration for HyperChat Studio
-# Copy this file to `.env` and fill in the secrets before running the API.
-
+# FastAPI application settings
 APP_NAME=HyperChat Studio
 DEBUG=false
 
-# Database connection string (SQLite by default)
-DATABASE_URL=sqlite+aiosqlite:///./chat.db
+# Database configuration
+DATABASE_URL=postgresql+asyncpg://hyperchat:hyperchat@localhost:5432/hyperchat
 
-# Vector store connection for knowledge embeddings
+# Vector store configuration
 VECTOR_STORE_URL=qdrant://localhost:6333
-
-# External API keys
-GROQ_API_KEY=your-groq-api-key
-ELEVENLABS_API_KEY=your-elevenlabs-api-key
 
 # CORS allowed origins (comma separated)
 ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
 
-# Optional secret used to authenticate realtime signalling clients
+# External API keys
+GROQ_API_KEY=
+ELEVENLABS_API_KEY=
+
+# Optional signalling secret for realtime features
 SIGNALLING_SECRET=

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -20,7 +20,12 @@ class Chat(Base):
     title: Mapped[str] = mapped_column(String, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 
-    messages: Mapped[list[Message]] = relationship("Message", back_populates="chat", cascade="all, delete-orphan")
+    messages: Mapped[list[Message]] = relationship(
+        "Message",
+        back_populates="chat",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
 
 
 class Message(Base):
@@ -35,4 +40,4 @@ class Message(Base):
     audio_url: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 
-    chat: Mapped[Chat] = relationship("Chat", back_populates="messages")
+    chat: Mapped[Chat] = relationship("Chat", back_populates="messages", lazy="selectin")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "fastapi",
     "uvicorn[standard]",
     "sqlalchemy[asyncio]",
+    "asyncpg",
     "pydantic",
     "pydantic-settings",
     "httpx",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: hyperchat-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: hyperchat
+      POSTGRES_PASSWORD: hyperchat
+      POSTGRES_DB: hyperchat
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
## Summary
- eager load chat messages to keep async SQLAlchemy access from raising greenlet errors
- document the Postgres workflow, update the sample environment file, and provide a Docker Compose stack for running the database
- add asyncpg to the backend dependencies for PostgreSQL connections

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e2b8ba699c832eb5d4fa87fc994b07