### PR TITLE
Improve Groq API request validation

### DIFF
--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -4,12 +4,71 @@ from __future__ import annotations
 
 from typing import AsyncIterator, Optional
 
+from contextlib import asynccontextmanager
+
 import httpx
 
 from app.config import get_settings
 
 GROQ_CHAT_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions"
 GROQ_TRANSCRIBE_ENDPOINT = "https://api.groq.com/openai/v1/audio/transcriptions"
+
+
+def _build_headers(*, accept: str, content_type: str | None = "application/json") -> dict[str, str]:
+    """Return default headers for Groq API requests."""
+
+    settings = get_settings()
+    if not settings.groq_api_key:
+        raise RuntimeError("GROQ_API_KEY must be configured to use Groq services.")
+
+    headers = {
+        "Authorization": f"Bearer {settings.groq_api_key}",
+        "Accept": accept,
+    }
+    if content_type:
+        headers["Content-Type"] = content_type
+    return headers
+
+
+def _combine_messages(
+    messages: list[dict[str, str]], knowledge_snippets: Optional[list[str]]
+) -> list[dict[str, str]]:
+    """Merge user/assistant history with optional knowledge snippets."""
+
+    merged = []
+    if knowledge_snippets:
+        merged.append(
+            {
+                "role": "system",
+                "content": "\n".join(snippet for snippet in knowledge_snippets if snippet),
+            }
+        )
+
+    merged.extend(messages)
+    return merged
+
+
+@asynccontextmanager
+async def _groq_stream_client(method: str, url: str, **kwargs):
+    """Context manager that raises helpful errors for Groq streaming requests."""
+
+    async with httpx.AsyncClient(timeout=None) as client:
+        try:
+            async with client.stream(method, url, **kwargs) as response:
+                response.raise_for_status()
+                yield response
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors only
+            detail: str
+            try:
+                payload = await exc.response.aread()
+                detail = payload.decode() if payload else exc.response.text
+            except Exception:  # noqa: BLE001 - best effort decoding
+                detail = "<unable to decode error payload>"
+
+            raise RuntimeError(
+                "Groq chat completion request failed with status "
+                f"{exc.response.status_code}: {detail}"
+            ) from exc
 
 
 async def generate_response(
@@ -19,55 +78,55 @@ async def generate_response(
 ) -> AsyncIterator[str]:
     """Stream completion tokens from Groq's chat completion API."""
 
-    settings = get_settings()
-    if not settings.groq_api_key:
-        raise RuntimeError("GROQ_API_KEY must be configured to stream responses.")
+    if not messages:
+        raise ValueError("At least one chat message is required to request a completion.")
 
-    headers = {"Authorization": f"Bearer {settings.groq_api_key}"}
-    system_messages = (
-        [
-            {
-                "role": "system",
-                "content": "\n".join(knowledge_snippets or []),
-            }
-        ]
-        if knowledge_snippets
-        else []
-    )
     payload = {
         "model": "mixtral-8x7b-32768",
-        "messages": system_messages + messages,
+        "messages": _combine_messages(messages, knowledge_snippets),
         "stream": stream,
     }
-    async with httpx.AsyncClient(timeout=None) as client:
-        async with client.stream("POST", GROQ_CHAT_ENDPOINT, headers=headers, json=payload) as response:
-            response.raise_for_status()
-            async for line in response.aiter_lines():
-                if not line.startswith("data:"):
-                    continue
-                payload_line = line.removeprefix("data:").strip()
-                if payload_line == "[DONE]":
-                    break
-                if payload_line:
-                    yield payload_line
+
+    headers = _build_headers(accept="text/event-stream")
+
+    async with _groq_stream_client(
+        "POST", GROQ_CHAT_ENDPOINT, headers=headers, json=payload
+    ) as response:
+        async for line in response.aiter_lines():
+            if not line.startswith("data:"):
+                continue
+            payload_line = line.removeprefix("data:").strip()
+            if payload_line == "[DONE]":
+                break
+            if payload_line:
+                yield payload_line
 
 
 async def transcribe_audio(audio_bytes: bytes, mime_type: str = "audio/webm") -> str:
     """Transcribe audio bytes using Groq's Whisper endpoint."""
 
-    settings = get_settings()
-    if not settings.groq_api_key:
-        raise RuntimeError("GROQ_API_KEY must be configured to transcribe audio.")
-
-    headers = {"Authorization": f"Bearer {settings.groq_api_key}"}
+    headers = _build_headers(accept="application/json", content_type=None)
     files = {"file": ("audio", audio_bytes, mime_type)}
     data = {"model": "whisper-large-v3"}
     async with httpx.AsyncClient(timeout=120.0) as client:
-        response = await client.post(
-            GROQ_TRANSCRIBE_ENDPOINT,
-            headers=headers,
-            data=data,
-            files=files,
-        )
-        response.raise_for_status()
+        try:
+            response = await client.post(
+                GROQ_TRANSCRIBE_ENDPOINT,
+                headers=headers,
+                data=data,
+                files=files,
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors only
+            detail: str
+            try:
+                body = await exc.response.aread()
+                detail = body.decode() if body else exc.response.text
+            except Exception:  # noqa: BLE001 - best effort decoding
+                detail = "<unable to decode error payload>"
+            raise RuntimeError(
+                "Groq transcription request failed with status "
+                f"{exc.response.status_code}: {detail}"
+            ) from exc
+
         return response.json().get("text", "")


### PR DESCRIPTION
## Summary
- add shared helpers that validate Groq credentials, headers, and message payloads before sending requests
- improve chat streaming to emit clearer runtime errors when Groq responds with an HTTP failure
- extend the transcription helper to reuse the new header handling and surface Groq error responses

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2c8bb2e80832e9eac01e8462b4752