### PR TITLE
Fix Groq chat streaming via OpenAI client

### DIFF
--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import AsyncIterator, Optional
 
-from contextlib import asynccontextmanager
-
 import httpx
+from openai import APIStatusError, AsyncOpenAI, OpenAIError
 
 from app.config import get_settings
 
-GROQ_CHAT_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions"
 GROQ_TRANSCRIBE_ENDPOINT = "https://api.groq.com/openai/v1/audio/transcriptions"
+
+_chat_client: AsyncOpenAI | None = None
 
 
 def _build_headers(*, accept: str, content_type: str | None = "application/json") -> dict[str, str]:
@@ -48,27 +48,22 @@ def _combine_messages(
     return merged
 
 
-@asynccontextmanager
-async def _groq_stream_client(method: str, url: str, **kwargs):
-    """Context manager that raises helpful errors for Groq streaming requests."""
+def _get_chat_client() -> AsyncOpenAI:
+    """Return a lazily instantiated Groq-compatible OpenAI client."""
 
-    async with httpx.AsyncClient(timeout=None) as client:
-        try:
-            async with client.stream(method, url, **kwargs) as response:
-                response.raise_for_status()
-                yield response
-        except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors only
-            detail: str
-            try:
-                payload = await exc.response.aread()
-                detail = payload.decode() if payload else exc.response.text
-            except Exception:  # noqa: BLE001 - best effort decoding
-                detail = "<unable to decode error payload>"
+    global _chat_client
 
-            raise RuntimeError(
-                "Groq chat completion request failed with status "
-                f"{exc.response.status_code}: {detail}"
-            ) from exc
+    if _chat_client is None:
+        settings = get_settings()
+        if not settings.groq_api_key:
+            raise RuntimeError("GROQ_API_KEY must be configured to use Groq services.")
+
+        _chat_client = AsyncOpenAI(
+            api_key=settings.groq_api_key,
+            base_url="https://api.groq.com/openai/v1",
+        )
+
+    return _chat_client
 
 
 async def generate_response(
@@ -81,25 +76,42 @@ async def generate_response(
     if not messages:
         raise ValueError("At least one chat message is required to request a completion.")
 
-    payload = {
-        "model": "mixtral-8x7b-32768",
-        "messages": _combine_messages(messages, knowledge_snippets),
-        "stream": stream,
-    }
+    client = _get_chat_client()
+    request_messages = _combine_messages(messages, knowledge_snippets)
 
-    headers = _build_headers(accept="text/event-stream")
+    try:
+        if stream:
+            completion = await client.chat.completions.create(
+                model="mixtral-8x7b-32768",
+                messages=request_messages,
+                stream=True,
+            )
+        else:
+            completion = await client.chat.completions.create(
+                model="mixtral-8x7b-32768",
+                messages=request_messages,
+                stream=False,
+            )
+    except APIStatusError as exc:
+        detail = exc.response.text if exc.response is not None else str(exc)
+        raise RuntimeError(
+            "Groq chat completion request failed with status "
+            f"{exc.status_code}: {detail}"
+        ) from exc
+    except OpenAIError as exc:  # pragma: no cover - network errors only
+        raise RuntimeError(f"Groq chat completion request failed: {exc}") from exc
 
-    async with _groq_stream_client(
-        "POST", GROQ_CHAT_ENDPOINT, headers=headers, json=payload
-    ) as response:
-        async for line in response.aiter_lines():
-            if not line.startswith("data:"):
-                continue
-            payload_line = line.removeprefix("data:").strip()
-            if payload_line == "[DONE]":
-                break
-            if payload_line:
-                yield payload_line
+    if not stream:
+        message = completion.choices[0].message.content if completion.choices else ""
+        if message:
+            yield message
+        return
+
+    try:
+        async for chunk in completion:
+            yield chunk.model_dump_json(exclude_none=True)
+    finally:
+        await completion.aclose()
 
 
 async def transcribe_audio(audio_bytes: bytes, mime_type: str = "audio/webm") -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic-settings",
     "httpx",
     "python-dotenv",
+    "openai",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- replace the manual Groq streaming request with the OpenAI AsyncOpenAI client configured for Groq so chat completions stream correctly and expose clearer errors
- add the OpenAI SDK as a backend dependency to support the new client

## Testing
- python -m compileall backend/app/services/llm.py

------
https://chatgpt.com/codex/tasks/task_e_68e2ca73635c832e8b3a921b29fff455