### PR TITLE
Update Groq model configuration and streaming cleanup

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -13,6 +13,7 @@ ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
 
 # External API keys
 GROQ_API_KEY=
+GROQ_MODEL=openai/gpt-oss-120b
 ELEVENLABS_API_KEY=
 
 # Optional signalling secret for realtime features

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,10 @@ class Settings(BaseSettings):
     )
 
     groq_api_key: str = Field("", description="API key for Groq LLM + STT services.")
+    groq_model: str = Field(
+        "openai/gpt-oss-120b",
+        description="Identifier of the Groq LLM model used for chat completions.",
+    )
     elevenlabs_api_key: str = Field("", description="API key for ElevenLabs text-to-speech streaming.")
 
     allowed_origins: List[str] = Field(

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -76,19 +76,20 @@ async def generate_response(
     if not messages:
         raise ValueError("At least one chat message is required to request a completion.")
 
+    settings = get_settings()
     client = _get_chat_client()
     request_messages = _combine_messages(messages, knowledge_snippets)
 
     try:
         if stream:
             completion = await client.chat.completions.create(
-                model="mixtral-8x7b-32768",
+                model=settings.groq_model,
                 messages=request_messages,
                 stream=True,
             )
         else:
             completion = await client.chat.completions.create(
-                model="mixtral-8x7b-32768",
+                model=settings.groq_model,
                 messages=request_messages,
                 stream=False,
             )
@@ -111,7 +112,7 @@ async def generate_response(
         async for chunk in completion:
             yield chunk.model_dump_json(exclude_none=True)
     finally:
-        await completion.aclose()
+        await completion.close()
 
 
 async def transcribe_audio(audio_bytes: bytes, mime_type: str = "audio/webm") -> str:


### PR DESCRIPTION
## Summary
- add configuration support for selecting the Groq chat model with a default of openai/gpt-oss-120b
- update the LLM service to respect the configured model and fix stream shutdown by calling close()
- document the GROQ_MODEL environment variable in the sample configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2d301526c832e82998c646bca545b