### PR TITLE
Fix markdown math plugin order

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -180,7 +180,7 @@ function MessageBubble({ role, content }: Props) {
       <div className="text-xs uppercase tracking-[0.3em] text-white/40">{role}</div>
       <div className="prose prose-invert mt-2 max-w-none text-sm leading-relaxed prose-headings:font-semibold prose-headings:text-white prose-strong:text-white">
         <ReactMarkdown
-          remarkPlugins={[remarkGfm, remarkMath]}
+          remarkPlugins={[remarkMath, remarkGfm]}
           rehypePlugins={[rehypeKatex]}
           components={markdownComponents}
         >


### PR DESCRIPTION
## Summary
- ensure markdown renders formulas by running remark-math before remark-gfm

## Testing
- npm run build *(fails: Rollup cannot resolve remark-gfm in the current setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d6dfdbec832e81020172c95daa46